### PR TITLE
add support for magento version 2.3.3 and php version 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
     - 7.1
     - 7.2
+    - 7.3
 
 install:
     - mkdir -p ~/.composer/

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "~7.1.0|~7.2.0|~7.3.0",
         "symfony/console": "~4.1.9",
         "magento/framework": "102.0.*",
         "magento/module-store": "101.0.*",


### PR DESCRIPTION
Hi Renato,
i updated the Module for the update to Magento 2.3.3 and update to php version 7.3.
I tested it and for me it works.

This time i updated the travis.yml as well